### PR TITLE
Added explicit triggering of pause event at the end of audio playback as it is not triggered on IE otherwise unlike other browsers

### DIFF
--- a/widget.js
+++ b/widget.js
@@ -108,6 +108,10 @@ define([
 							cued = false;
 						});
 				}
+				else if (position == duration)
+				{
+					return me.emit("audio5js/do/pause");
+				}
 			});
 		},
 


### PR DESCRIPTION
The problem is that no event is fired at the end of the playback on IE, the UI is therefore not updated accordingly, unlike other browsers in which the event is triggered implicitly. This fix explicitly triggers the pause event at the end of the playback.
