### PR TITLE
UTC fixes for moment.js

### DIFF
--- a/$duration.js
+++ b/$duration.js
@@ -2,6 +2,6 @@ define([ "moment" ], function (moment) {
 	return function $duration(duration, format) {
 		return this
 			.find(".duration")
-			.text(moment(duration * 1000).format(format || "mm:ss"));
+			.text(moment(duration * 1000).utc().format(format || "mm:ss"));
 	};
 });

--- a/$position.js
+++ b/$position.js
@@ -4,7 +4,7 @@ define([ "moment" ], function (moment) {
 
 		return this
 			.find(".position")
-			.text(moment(position * 1000).format(format || "mm:ss"))
+			.text(moment(position * 1000).utc().format(format || "mm:ss"))
 			.end()
 			.find(".progress > .progress-bar")
 			.width(progress + "%")


### PR DESCRIPTION
From skype:

> Just needs to add the ".utc()" conversion as follow to:
> - $position.js: ".text(moment(position * 1000).utc().format(format || "mm:ss"))" 
> - $duration.js: ".text(moment(duration * 1000).utc().format(format || "mm:ss"));"
>
> The reason for this is that MomentJs converts time to local time by default and we didn't noticed before as the timers don't show hours that's until today when the guys in bangalore showed us that all timers have an extra half hour, it happened that they are in a half hour time zone GMT +5:30