### PR TITLE
fix audio issue when cannot play twice on old IE versions

### DIFF
--- a/widget.js
+++ b/widget.js
@@ -94,21 +94,7 @@ define([
 							cued = false;
 						});
 				}
-				else if (position !== duration && position > cue_out) {
-					cued = true;
-					return me
-						.emit("audio5js/do/pause")
-						.tap(function () {
-							return me.emit("audio5js/do/seek", cue_out);
-						})
-						.tap(function () {
-							return me.emit("audio5js/ended");
-						})
-						.ensure(function () {
-							cued = false;
-						});
-				}
-				else if (duration - position <= 0.2) {
+				else if ( position !== duration && position > cue_out || duration - position <= 0.2) {
 					cued = true;
 					return me
 						.emit("audio5js/do/pause")


### PR DESCRIPTION
This fixes an issue that happens sometimes with all versions of IE (ie8 and ie9).

The issue is that after playing the audio file once, and clicking for play it as second time, the audio player says 0 plays left and the file doesn't play.

We can reproduce this in the previous version of the code forcing the data to enter in the condition (position !== duration && position > cue_out) and adding as cue_out a second before than the real duration of the file.

Can seem difficult or impossible to happen but I found that in IE8 and IE9 the intervals for the movement of the header fluctuates and the duration of the file returned by the audio5js plugin can vary to the real ones generating this 3 previos conditions to happen and making this bug look as RANDOM (very difficult to reproduce).


Here I copy an EMAIL I sent with some of the data extracted from a comparative analysis I did between how the plugin performs depending on the browser:

```
HI guys,

As I was explaining to you this morning in the daily standup I have been analysing the way of working of the audio5js player depending on the browser.

Before start, just let me remember you guys what are the main variables:

- cue_in: Starting position (in the audio-check is 0, inside of the audio task is 8)
- cue_out: Ending position (in the audio-check is 8, inside of the audio task is the duration of the file === duration variable)
- duration: Is the duration of the file, and this value comes from the html5 audio event.
- position: is the position of the header on each 250ms (250ms is the setInterval time set on the library).

After this introduction, here I paste the interval differences I have seen between two consecutive position times in each browser:

IE9					||			CHROME
===					||			========
					||
0,2521972656 sec		||			0,255409 sec
0,2435379028 sec		||			0,255409 sec
0,2558746338 sec		||			0,255409 sec
0,2473907471 sec		||			0,255409 sec
0,2672119149 sec		||			0,255409 sec

(attached console.log images at the end of this email)

Q1: What happens if I force a duration/cue_out bigger than the audio file length?

First of all, the duration of the file returned by IE9 is slightly different to the duration returned by Chrome

IE9 ==> duration of the file: 178,625335, file stops by itself in 178.625335
CHROME  ==> duration of the file: 178,625333, file stops by itself in 178,625333

What happens in the audio cue_out is bigger than the audio file is that the file stops by itself. Because the code that moves the head to the cue_in (8 sec) has not been called the audio-check is reproduced again and the visual feedback of the audio progress bar is not correct but, YOU CAN STILL CAN LISTEN THE AUDIO FILE AND YOU DONT LOSE AN AUDIO PLAY.

As you can see, the data returned by chrome is exact when the IE9 intervals are fluctuating, even the duration of the file is different, but as you can see as well the differences are in the order of centisecs so OUR FIX OF STOP THE AUDIO PLAYER ON THE REGIM OF 0,2 sec SHOULD FIX THIS ISSUE AND ACTUALLY DOES.

Q2: There is some event triggered in the library when the audio file ends?

Yes, there is an event triggered but.
1. It won’t fix the reported issue, is not related with not knowing that the audio file has ended, the issue is related with not been able to reproduce more than 2 times the file and thats related with the troopjs layout that checks the plays left we have set up on our payload.

2. We can’t delegate on that event because as you know for example the end of the audio check is not the end of the audio file or If we stop the audio file before the end (0,2 sec fix) we won’t trigger it.

Q3: What are the technologies used in each browser for playing the audio file??

Basically on any browser that can use the html5 audio tag will use it, the ones that can’t (like ie9) will use the flash player.


Basically I think we need to reproduce first the issue to know what exactly happens, is the UI showing 0 plays left?  if yes, when you click second time it says before 1 play left and suddenly passes to 0 plays left?

Is maybe play button disabled? Is there a real issue happening? there is any pattern?

My recommendation is to do an intensive QA of the issue with a real old shitty windows-ie9 machine and try to reproduce it.
```